### PR TITLE
1.20.4 menu fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>xyz.xenondevs.invui</groupId>
             <artifactId>invui</artifactId>
-            <version>1.23</version>
+            <version>1.24</version>
             <type>pom</type>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>xyz.xenondevs.invui</groupId>
             <artifactId>invui</artifactId>
-            <version>1.24</version>
+            <version>1.25</version>
             <type>pom</type>
         </dependency>
 

--- a/src/main/java/ru/oshifugo/functionalclans/command/gui_items/settings/Status.java
+++ b/src/main/java/ru/oshifugo/functionalclans/command/gui_items/settings/Status.java
@@ -66,7 +66,7 @@ public class Status extends ItemsBase{
                 if (members.containsKey(player.getName())) {
                     String clanName = members.get(player.getName())[2];
                     Clan.setStatus(clanName, renamed);
-                    player.sendMessage(getTranslate().get("settings.status", true));
+                    player.sendMessage(getTranslate().get("status.done", true));
                 }
                 break;
         }


### PR DESCRIPTION
На spigotmc жаловались, что меню сломано на 1.20.4 - просто обновил invui.
фикс неправильного отображения строки после смены статуса в клане